### PR TITLE
Variable source priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Respect `variable_priority`, added in providers releases [0.0.6](https://github.com/nbering/terraform-provider-ansible/releases/tag/v0.0.6)/[1.0.2](https://github.com/nbering/terraform-provider-ansible/releases/tag/v1.0.2)
+
+### Changed
+- List values in output are now sorted for consistency, and to make regression testing easier
+- With state files where `variable_priority` is not set, the default values of 50 (for `ansible_host` and `ansible_group`) and 60 (for `ansible_host_var` and `ansible_group_var`) will be inferred, changing variable merging behaviour
 
 ## [2.1.0] - 2019-05-20
 ### Added

--- a/sample_data/0.11.x/basic/main.tf
+++ b/sample_data/0.11.x/basic/main.tf
@@ -1,6 +1,15 @@
+terraform {
+  required_version = "~> 0.11.0"
+}
+
+provider "ansible" {
+  version = "~> 0.0.5"
+}
+
 resource "ansible_host" "www" {
   inventory_hostname = "www.example.com"
   groups             = ["example", "web"]
+
   vars {
     fooo = "aaa"
     bar  = "bbb"
@@ -10,6 +19,7 @@ resource "ansible_host" "www" {
 resource "ansible_host" "db" {
   inventory_hostname = "db.example.com"
   groups             = ["example", "db"]
+
   vars {
     fooo = "ccc"
     bar  = "ddd"
@@ -19,6 +29,7 @@ resource "ansible_host" "db" {
 resource "ansible_group" "web" {
   inventory_group_name = "web"
   children             = ["foo", "bar", "baz"]
+
   vars {
     foo = "bar"
     bar = 2

--- a/sample_data/0.11.x/count-advanced/main.tf
+++ b/sample_data/0.11.x/count-advanced/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_version = "~> 0.11.0"
+}
+
+provider "ansible" {
+  version = "~> 0.0.5"
+}
+
 variable "hostnames" {
   type = "list"
 

--- a/sample_data/0.11.x/count-basic/main.tf
+++ b/sample_data/0.11.x/count-basic/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_version = "~> 0.11.0"
+}
+
+provider "ansible" {
+  version = "~> 0.0.5"
+}
+
 resource "ansible_host" "count_sample" {
   count              = 5
   inventory_hostname = "count-sample-${count.index}.example.com"

--- a/sample_data/0.11.x/individual-vars/expect.json
+++ b/sample_data/0.11.x/individual-vars/expect.json
@@ -8,7 +8,7 @@
       "www.example.com": {
         "bar": "bbb",
         "db_host": "db.example.com",
-        "foo": "aaa"
+        "foo": "eee"
       }
     }
   },

--- a/sample_data/0.11.x/individual-vars/expect.json
+++ b/sample_data/0.11.x/individual-vars/expect.json
@@ -38,10 +38,17 @@
     "vars": {}
   },
   "web": {
-    "children": [],
+    "children": [
+      "bar",
+      "baz",
+      "foo"
+    ],
     "hosts": [
       "www.example.com"
     ],
-    "vars": {}
+    "vars": {
+      "bar": "2",
+      "foo": "fff"
+    }
   }
 }

--- a/sample_data/0.11.x/individual-vars/main.tf
+++ b/sample_data/0.11.x/individual-vars/main.tf
@@ -38,6 +38,22 @@ resource "ansible_host_var" "override" {
   value              = "eee"
 }
 
+resource "ansible_group" "web" {
+  inventory_group_name = "web"
+  children             = ["foo", "bar", "baz"]
+
+  vars = {
+    foo = "bar"
+    bar = 2
+  }
+}
+
+resource "ansible_group_var" "override" {
+  inventory_group_name = "web"
+  key                  = "foo"
+  value                = "fff"
+}
+
 resource "ansible_group_var" "extra" {
   inventory_group_name = "db"
   key                  = "ansible_user"

--- a/sample_data/0.11.x/individual-vars/main.tf
+++ b/sample_data/0.11.x/individual-vars/main.tf
@@ -32,6 +32,12 @@ resource "ansible_host_var" "extra" {
   value              = "${ansible_host.db.inventory_hostname}"
 }
 
+resource "ansible_host_var" "override" {
+  inventory_hostname = "www.example.com"
+  key                = "foo"
+  value              = "eee"
+}
+
 resource "ansible_group_var" "extra" {
   inventory_group_name = "db"
   key                  = "ansible_user"

--- a/sample_data/0.11.x/individual-vars/main.tf
+++ b/sample_data/0.11.x/individual-vars/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "ansible" {
-  version = "~> 0.0.5"
+  version = "~> 0.0.6"
 }
 
 resource "ansible_host" "www" {
@@ -38,6 +38,13 @@ resource "ansible_host_var" "override" {
   value              = "eee"
 }
 
+resource "ansible_host_var" "underride" {
+  inventory_hostname = "www.example.com"
+  variable_priority  = 10
+  key                = "bar"
+  value              = "ggg"
+}
+
 resource "ansible_group" "web" {
   inventory_group_name = "web"
   children             = ["foo", "bar", "baz"]
@@ -52,6 +59,13 @@ resource "ansible_group_var" "override" {
   inventory_group_name = "web"
   key                  = "foo"
   value                = "fff"
+}
+
+resource "ansible_group_var" "underride" {
+  inventory_group_name = "web"
+  variable_priority    = 10
+  key                  = "bar"
+  value                = "hhh"
 }
 
 resource "ansible_group_var" "extra" {

--- a/sample_data/0.11.x/individual-vars/main.tf
+++ b/sample_data/0.11.x/individual-vars/main.tf
@@ -1,6 +1,15 @@
+terraform {
+  required_version = "~> 0.11.0"
+}
+
+provider "ansible" {
+  version = "~> 0.0.5"
+}
+
 resource "ansible_host" "www" {
   inventory_hostname = "www.example.com"
   groups             = ["example", "web"]
+
   vars = {
     foo = "aaa"
     bar = "bbb"
@@ -10,6 +19,7 @@ resource "ansible_host" "www" {
 resource "ansible_host" "db" {
   inventory_hostname = "db.example.com"
   groups             = ["example", "db"]
+
   vars = {
     foo = "ccc"
     bar = "ddd"

--- a/sample_data/0.11.x/individual-vars/terraform.tfstate
+++ b/sample_data/0.11.x/individual-vars/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.14",
-    "serial": 2,
+    "serial": 3,
     "lineage": "fd5627d8-41cc-2c58-f463-66453b5f2978",
     "modules": [
         {
@@ -10,6 +10,28 @@
             ],
             "outputs": {},
             "resources": {
+                "ansible_group.web": {
+                    "type": "ansible_group",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "web",
+                        "attributes": {
+                            "children.#": "3",
+                            "children.0": "foo",
+                            "children.1": "bar",
+                            "children.2": "baz",
+                            "id": "web",
+                            "inventory_group_name": "web",
+                            "vars.%": "2",
+                            "vars.bar": "2",
+                            "vars.foo": "bar"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.ansible"
+                },
                 "ansible_group_var.extra": {
                     "type": "ansible_group_var",
                     "depends_on": [],
@@ -20,6 +42,23 @@
                             "inventory_group_name": "db",
                             "key": "ansible_user",
                             "value": "postgres"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.ansible"
+                },
+                "ansible_group_var.override": {
+                    "type": "ansible_group_var",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "web/foo",
+                        "attributes": {
+                            "id": "web/foo",
+                            "inventory_group_name": "web",
+                            "key": "foo",
+                            "value": "fff"
                         },
                         "meta": {},
                         "tainted": false

--- a/sample_data/0.11.x/individual-vars/terraform.tfstate
+++ b/sample_data/0.11.x/individual-vars/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.14",
-    "serial": 1,
+    "serial": 2,
     "lineage": "fd5627d8-41cc-2c58-f463-66453b5f2978",
     "modules": [
         {
@@ -81,6 +81,23 @@
                             "inventory_hostname": "www.example.com",
                             "key": "db_host",
                             "value": "db.example.com"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.ansible"
+                },
+                "ansible_host_var.override": {
+                    "type": "ansible_host_var",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "www.example.com/foo",
+                        "attributes": {
+                            "id": "www.example.com/foo",
+                            "inventory_hostname": "www.example.com",
+                            "key": "foo",
+                            "value": "eee"
                         },
                         "meta": {},
                         "tainted": false

--- a/sample_data/0.11.x/individual-vars/terraform.tfstate
+++ b/sample_data/0.11.x/individual-vars/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.11.14",
-    "serial": 3,
+    "serial": 4,
     "lineage": "fd5627d8-41cc-2c58-f463-66453b5f2978",
     "modules": [
         {
@@ -22,6 +22,7 @@
                             "children.2": "baz",
                             "id": "web",
                             "inventory_group_name": "web",
+                            "variable_priority": "50",
                             "vars.%": "2",
                             "vars.bar": "2",
                             "vars.foo": "bar"
@@ -41,7 +42,8 @@
                             "id": "db/ansible_user",
                             "inventory_group_name": "db",
                             "key": "ansible_user",
-                            "value": "postgres"
+                            "value": "postgres",
+                            "variable_priority": "60"
                         },
                         "meta": {},
                         "tainted": false
@@ -58,7 +60,26 @@
                             "id": "web/foo",
                             "inventory_group_name": "web",
                             "key": "foo",
-                            "value": "fff"
+                            "value": "fff",
+                            "variable_priority": "60"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.ansible"
+                },
+                "ansible_group_var.underride": {
+                    "type": "ansible_group_var",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "web/bar",
+                        "attributes": {
+                            "id": "web/bar",
+                            "inventory_group_name": "web",
+                            "key": "bar",
+                            "value": "hhh",
+                            "variable_priority": "10"
                         },
                         "meta": {},
                         "tainted": false
@@ -77,6 +98,7 @@
                             "groups.1": "db",
                             "id": "db.example.com",
                             "inventory_hostname": "db.example.com",
+                            "variable_priority": "50",
                             "vars.%": "2",
                             "vars.bar": "ddd",
                             "vars.foo": "ccc"
@@ -98,6 +120,7 @@
                             "groups.1": "web",
                             "id": "www.example.com",
                             "inventory_hostname": "www.example.com",
+                            "variable_priority": "50",
                             "vars.%": "2",
                             "vars.bar": "bbb",
                             "vars.foo": "aaa"
@@ -119,7 +142,8 @@
                             "id": "www.example.com/db_host",
                             "inventory_hostname": "www.example.com",
                             "key": "db_host",
-                            "value": "db.example.com"
+                            "value": "db.example.com",
+                            "variable_priority": "60"
                         },
                         "meta": {},
                         "tainted": false
@@ -136,7 +160,26 @@
                             "id": "www.example.com/foo",
                             "inventory_hostname": "www.example.com",
                             "key": "foo",
-                            "value": "eee"
+                            "value": "eee",
+                            "variable_priority": "60"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.ansible"
+                },
+                "ansible_host_var.underride": {
+                    "type": "ansible_host_var",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "www.example.com/bar",
+                        "attributes": {
+                            "id": "www.example.com/bar",
+                            "inventory_hostname": "www.example.com",
+                            "key": "bar",
+                            "value": "ggg",
+                            "variable_priority": "10"
                         },
                         "meta": {},
                         "tainted": false

--- a/sample_data/0.12.x/basic/main.tf
+++ b/sample_data/0.12.x/basic/main.tf
@@ -1,6 +1,15 @@
+terraform {
+  required_version = "~> 0.12.0"
+}
+
+provider "ansible" {
+  version = "~> 1.0.1"
+}
+
 resource "ansible_host" "www" {
   inventory_hostname = "www.example.com"
   groups             = ["example", "web"]
+
   vars = {
     fooo = "aaa"
     bar  = "bbb"
@@ -10,6 +19,7 @@ resource "ansible_host" "www" {
 resource "ansible_host" "db" {
   inventory_hostname = "db.example.com"
   groups             = ["example", "db"]
+
   vars = {
     fooo = "ccc"
     bar  = "ddd"
@@ -19,6 +29,7 @@ resource "ansible_host" "db" {
 resource "ansible_group" "web" {
   inventory_group_name = "web"
   children             = ["foo", "bar", "baz"]
+
   vars = {
     foo = "bar"
     bar = 2

--- a/sample_data/0.12.x/count-advanced/main.tf
+++ b/sample_data/0.12.x/count-advanced/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_version = "~> 0.12.0"
+}
+
+provider "ansible" {
+  version = "~> 1.0.1"
+}
+
 variable "hostnames" {
   type = "list"
 

--- a/sample_data/0.12.x/count-basic/main.tf
+++ b/sample_data/0.12.x/count-basic/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_version = "~> 0.12.0"
+}
+
+provider "ansible" {
+  version = "~> 1.0.1"
+}
+
 resource "ansible_host" "count_sample" {
   count              = 5
   inventory_hostname = "count-sample-${count.index}.example.com"

--- a/sample_data/0.12.x/individual-vars/expect.json
+++ b/sample_data/0.12.x/individual-vars/expect.json
@@ -8,7 +8,7 @@
       "www.example.com": {
         "bar": "bbb",
         "db_host": "db.example.com",
-        "foo": "aaa"
+        "foo": "eee"
       }
     }
   },

--- a/sample_data/0.12.x/individual-vars/expect.json
+++ b/sample_data/0.12.x/individual-vars/expect.json
@@ -38,10 +38,17 @@
     "vars": {}
   },
   "web": {
-    "children": [],
+    "children": [
+      "bar",
+      "baz",
+      "foo"
+    ],
     "hosts": [
       "www.example.com"
     ],
-    "vars": {}
+    "vars": {
+      "bar": "2",
+      "foo": "fff"
+    }
   }
 }

--- a/sample_data/0.12.x/individual-vars/main.tf
+++ b/sample_data/0.12.x/individual-vars/main.tf
@@ -38,6 +38,22 @@ resource "ansible_host_var" "override" {
   value              = "eee"
 }
 
+resource "ansible_group" "web" {
+  inventory_group_name = "web"
+  children             = ["foo", "bar", "baz"]
+
+  vars = {
+    foo = "bar"
+    bar = 2
+  }
+}
+
+resource "ansible_group_var" "override" {
+  inventory_group_name = "web"
+  key                  = "foo"
+  value                = "fff"
+}
+
 resource "ansible_group_var" "extra" {
   inventory_group_name = "db"
   key                  = "ansible_user"

--- a/sample_data/0.12.x/individual-vars/main.tf
+++ b/sample_data/0.12.x/individual-vars/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "ansible" {
-  version = "~> 1.0.2"
+  version = "~> 1.0.1"
 }
 
 resource "ansible_host" "www" {
@@ -38,13 +38,6 @@ resource "ansible_host_var" "override" {
   value              = "eee"
 }
 
-resource "ansible_host_var" "underride" {
-  inventory_hostname = "www.example.com"
-  priority           = 10
-  key                = "bar"
-  value              = "ggg"
-}
-
 resource "ansible_group" "web" {
   inventory_group_name = "web"
   children             = ["foo", "bar", "baz"]
@@ -59,13 +52,6 @@ resource "ansible_group_var" "override" {
   inventory_group_name = "web"
   key                  = "foo"
   value                = "fff"
-}
-
-resource "ansible_group_var" "underride" {
-  inventory_group_name = "web"
-  priority             = 10
-  key                  = "bar"
-  value                = "hhh"
 }
 
 resource "ansible_group_var" "extra" {

--- a/sample_data/0.12.x/individual-vars/main.tf
+++ b/sample_data/0.12.x/individual-vars/main.tf
@@ -1,6 +1,15 @@
+terraform {
+  required_version = "~> 0.12.0"
+}
+
+provider "ansible" {
+  version = "~> 1.0.1"
+}
+
 resource "ansible_host" "www" {
   inventory_hostname = "www.example.com"
   groups             = ["example", "web"]
+
   vars = {
     foo = "aaa"
     bar = "bbb"
@@ -10,6 +19,7 @@ resource "ansible_host" "www" {
 resource "ansible_host" "db" {
   inventory_hostname = "db.example.com"
   groups             = ["example", "db"]
+
   vars = {
     foo = "ccc"
     bar = "ddd"
@@ -20,6 +30,12 @@ resource "ansible_host_var" "extra" {
   inventory_hostname = "www.example.com"
   key                = "db_host"
   value              = "${ansible_host.db.inventory_hostname}"
+}
+
+resource "ansible_host_var" "override" {
+  inventory_hostname = "www.example.com"
+  key                = "foo"
+  value              = "eee"
 }
 
 resource "ansible_group_var" "extra" {

--- a/sample_data/0.12.x/individual-vars/main.tf
+++ b/sample_data/0.12.x/individual-vars/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "ansible" {
-  version = "~> 1.0.1"
+  version = "~> 1.0.2"
 }
 
 resource "ansible_host" "www" {
@@ -38,6 +38,13 @@ resource "ansible_host_var" "override" {
   value              = "eee"
 }
 
+resource "ansible_host_var" "underride" {
+  inventory_hostname = "www.example.com"
+  priority           = 10
+  key                = "bar"
+  value              = "ggg"
+}
+
 resource "ansible_group" "web" {
   inventory_group_name = "web"
   children             = ["foo", "bar", "baz"]
@@ -52,6 +59,13 @@ resource "ansible_group_var" "override" {
   inventory_group_name = "web"
   key                  = "foo"
   value                = "fff"
+}
+
+resource "ansible_group_var" "underride" {
+  inventory_group_name = "web"
+  priority             = 10
+  key                  = "bar"
+  value                = "hhh"
 }
 
 resource "ansible_group_var" "extra" {

--- a/sample_data/0.12.x/individual-vars/main.tf
+++ b/sample_data/0.12.x/individual-vars/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "ansible" {
-  version = "~> 1.0.1"
+  version = "~> 1.0.2"
 }
 
 resource "ansible_host" "www" {
@@ -38,6 +38,13 @@ resource "ansible_host_var" "override" {
   value              = "eee"
 }
 
+resource "ansible_host_var" "underride" {
+  inventory_hostname = "www.example.com"
+  variable_priority  = 10
+  key                = "bar"
+  value              = "ggg"
+}
+
 resource "ansible_group" "web" {
   inventory_group_name = "web"
   children             = ["foo", "bar", "baz"]
@@ -52,6 +59,13 @@ resource "ansible_group_var" "override" {
   inventory_group_name = "web"
   key                  = "foo"
   value                = "fff"
+}
+
+resource "ansible_group_var" "underride" {
+  inventory_group_name = "web"
+  variable_priority    = 10
+  key                  = "bar"
+  value                = "hhh"
 }
 
 resource "ansible_group_var" "extra" {

--- a/sample_data/0.12.x/individual-vars/terraform.tfstate
+++ b/sample_data/0.12.x/individual-vars/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "0.12.0",
-  "serial": 10,
+  "serial": 20,
   "lineage": "40cc4be1-f5ea-02d6-b06a-26813e05cd13",
   "outputs": {},
   "resources": [
@@ -21,6 +21,7 @@
             ],
             "id": "web",
             "inventory_group_name": "web",
+            "variable_priority": 50,
             "vars": {
               "bar": "2",
               "foo": "bar"
@@ -41,7 +42,8 @@
             "id": "db/ansible_user",
             "inventory_group_name": "db",
             "key": "ansible_user",
-            "value": "postgres"
+            "value": "postgres",
+            "variable_priority": 60
           }
         }
       ]
@@ -58,7 +60,26 @@
             "id": "web/foo",
             "inventory_group_name": "web",
             "key": "foo",
-            "value": "fff"
+            "value": "fff",
+            "variable_priority": 60
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "ansible_group_var",
+      "name": "underride",
+      "provider": "provider.ansible",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "web/bar",
+            "inventory_group_name": "web",
+            "key": "bar",
+            "value": "hhh",
+            "variable_priority": 10
           }
         }
       ]
@@ -78,6 +99,7 @@
             ],
             "id": "db.example.com",
             "inventory_hostname": "db.example.com",
+            "variable_priority": 50,
             "vars": {
               "bar": "ddd",
               "foo": "ccc"
@@ -101,6 +123,7 @@
             ],
             "id": "www.example.com",
             "inventory_hostname": "www.example.com",
+            "variable_priority": 50,
             "vars": {
               "bar": "bbb",
               "foo": "aaa"
@@ -121,7 +144,8 @@
             "id": "www.example.com/db_host",
             "inventory_hostname": "www.example.com",
             "key": "db_host",
-            "value": "db.example.com"
+            "value": "db.example.com",
+            "variable_priority": 60
           },
           "depends_on": [
             "ansible_host.db"
@@ -141,7 +165,26 @@
             "id": "www.example.com/foo",
             "inventory_hostname": "www.example.com",
             "key": "foo",
-            "value": "eee"
+            "value": "eee",
+            "variable_priority": 60
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "ansible_host_var",
+      "name": "underride",
+      "provider": "provider.ansible",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "www.example.com/bar",
+            "inventory_hostname": "www.example.com",
+            "key": "bar",
+            "value": "ggg",
+            "variable_priority": 10
           }
         }
       ]

--- a/sample_data/0.12.x/individual-vars/terraform.tfstate
+++ b/sample_data/0.12.x/individual-vars/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "0.12.0",
-  "serial": 20,
+  "serial": 10,
   "lineage": "40cc4be1-f5ea-02d6-b06a-26813e05cd13",
   "outputs": {},
   "resources": [
@@ -21,7 +21,6 @@
             ],
             "id": "web",
             "inventory_group_name": "web",
-            "priority": 50,
             "vars": {
               "bar": "2",
               "foo": "bar"
@@ -42,7 +41,6 @@
             "id": "db/ansible_user",
             "inventory_group_name": "db",
             "key": "ansible_user",
-            "priority": 60,
             "value": "postgres"
           }
         }
@@ -60,26 +58,7 @@
             "id": "web/foo",
             "inventory_group_name": "web",
             "key": "foo",
-            "priority": 60,
             "value": "fff"
-          }
-        }
-      ]
-    },
-    {
-      "mode": "managed",
-      "type": "ansible_group_var",
-      "name": "underride",
-      "provider": "provider.ansible",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "id": "web/bar",
-            "inventory_group_name": "web",
-            "key": "bar",
-            "priority": 10,
-            "value": "hhh"
           }
         }
       ]
@@ -99,7 +78,6 @@
             ],
             "id": "db.example.com",
             "inventory_hostname": "db.example.com",
-            "priority": 50,
             "vars": {
               "bar": "ddd",
               "foo": "ccc"
@@ -123,7 +101,6 @@
             ],
             "id": "www.example.com",
             "inventory_hostname": "www.example.com",
-            "priority": 50,
             "vars": {
               "bar": "bbb",
               "foo": "aaa"
@@ -144,7 +121,6 @@
             "id": "www.example.com/db_host",
             "inventory_hostname": "www.example.com",
             "key": "db_host",
-            "priority": 60,
             "value": "db.example.com"
           },
           "depends_on": [
@@ -165,26 +141,7 @@
             "id": "www.example.com/foo",
             "inventory_hostname": "www.example.com",
             "key": "foo",
-            "priority": 60,
             "value": "eee"
-          }
-        }
-      ]
-    },
-    {
-      "mode": "managed",
-      "type": "ansible_host_var",
-      "name": "underride",
-      "provider": "provider.ansible",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "id": "www.example.com/bar",
-            "inventory_hostname": "www.example.com",
-            "key": "bar",
-            "priority": 10,
-            "value": "ggg"
           }
         }
       ]

--- a/sample_data/0.12.x/individual-vars/terraform.tfstate
+++ b/sample_data/0.12.x/individual-vars/terraform.tfstate
@@ -1,10 +1,34 @@
 {
   "version": 4,
   "terraform_version": "0.12.0",
-  "serial": 7,
+  "serial": 10,
   "lineage": "40cc4be1-f5ea-02d6-b06a-26813e05cd13",
   "outputs": {},
   "resources": [
+    {
+      "mode": "managed",
+      "type": "ansible_group",
+      "name": "web",
+      "provider": "provider.ansible",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "children": [
+              "foo",
+              "bar",
+              "baz"
+            ],
+            "id": "web",
+            "inventory_group_name": "web",
+            "vars": {
+              "bar": "2",
+              "foo": "bar"
+            }
+          }
+        }
+      ]
+    },
     {
       "mode": "managed",
       "type": "ansible_group_var",
@@ -18,6 +42,23 @@
             "inventory_group_name": "db",
             "key": "ansible_user",
             "value": "postgres"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "ansible_group_var",
+      "name": "override",
+      "provider": "provider.ansible",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "web/foo",
+            "inventory_group_name": "web",
+            "key": "foo",
+            "value": "fff"
           }
         }
       ]

--- a/sample_data/0.12.x/individual-vars/terraform.tfstate
+++ b/sample_data/0.12.x/individual-vars/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "0.12.0",
-  "serial": 10,
+  "serial": 20,
   "lineage": "40cc4be1-f5ea-02d6-b06a-26813e05cd13",
   "outputs": {},
   "resources": [
@@ -21,6 +21,7 @@
             ],
             "id": "web",
             "inventory_group_name": "web",
+            "priority": 50,
             "vars": {
               "bar": "2",
               "foo": "bar"
@@ -41,6 +42,7 @@
             "id": "db/ansible_user",
             "inventory_group_name": "db",
             "key": "ansible_user",
+            "priority": 60,
             "value": "postgres"
           }
         }
@@ -58,7 +60,26 @@
             "id": "web/foo",
             "inventory_group_name": "web",
             "key": "foo",
+            "priority": 60,
             "value": "fff"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "ansible_group_var",
+      "name": "underride",
+      "provider": "provider.ansible",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "web/bar",
+            "inventory_group_name": "web",
+            "key": "bar",
+            "priority": 10,
+            "value": "hhh"
           }
         }
       ]
@@ -78,6 +99,7 @@
             ],
             "id": "db.example.com",
             "inventory_hostname": "db.example.com",
+            "priority": 50,
             "vars": {
               "bar": "ddd",
               "foo": "ccc"
@@ -101,6 +123,7 @@
             ],
             "id": "www.example.com",
             "inventory_hostname": "www.example.com",
+            "priority": 50,
             "vars": {
               "bar": "bbb",
               "foo": "aaa"
@@ -121,6 +144,7 @@
             "id": "www.example.com/db_host",
             "inventory_hostname": "www.example.com",
             "key": "db_host",
+            "priority": 60,
             "value": "db.example.com"
           },
           "depends_on": [
@@ -141,7 +165,26 @@
             "id": "www.example.com/foo",
             "inventory_hostname": "www.example.com",
             "key": "foo",
+            "priority": 60,
             "value": "eee"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "ansible_host_var",
+      "name": "underride",
+      "provider": "provider.ansible",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "www.example.com/bar",
+            "inventory_hostname": "www.example.com",
+            "key": "bar",
+            "priority": 10,
+            "value": "ggg"
           }
         }
       ]

--- a/sample_data/0.12.x/individual-vars/terraform.tfstate
+++ b/sample_data/0.12.x/individual-vars/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "0.12.0",
-  "serial": 5,
+  "serial": 7,
   "lineage": "40cc4be1-f5ea-02d6-b06a-26813e05cd13",
   "outputs": {},
   "resources": [
@@ -85,6 +85,23 @@
           "depends_on": [
             "ansible_host.db"
           ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "ansible_host_var",
+      "name": "override",
+      "provider": "provider.ansible",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "www.example.com/foo",
+            "inventory_hostname": "www.example.com",
+            "key": "foo",
+            "value": "eee"
+          }
         }
       ]
     }

--- a/terraform.py
+++ b/terraform.py
@@ -107,8 +107,8 @@ class TerraformResource(object):
 
         priority = 0
 
-        if self.read_int_attr("priority") is not None:
-            priority = self.read_int_attr("priority")
+        if self.read_int_attr("variable_priority") is not None:
+            priority = self.read_int_attr("variable_priority")
         elif self.type() in TerraformResource.DEFAULT_PRIORITIES:
             priority = TerraformResource.DEFAULT_PRIORITIES[self.type()]
 

--- a/terraform.py
+++ b/terraform.py
@@ -107,8 +107,8 @@ class TerraformResource(object):
 
         priority = 0
 
-        if self.read_attr("priority") is not None:
-            priority = self.read_attr("priority")
+        if self.read_int_attr("priority") is not None:
+            priority = self.read_int_attr("priority")
         elif self.type() in TerraformResource.DEFAULT_PRIORITIES:
             priority = TerraformResource.DEFAULT_PRIORITIES[self.type()]
 
@@ -165,6 +165,17 @@ class TerraformResource(object):
 
             return out
         return attrs.get(key, None)
+
+    def read_int_attr(self, key):
+        '''
+        Read an attribute from state an convert it to type Int.
+        '''
+        val = self.read_attr(key)
+
+        if val is not None:
+            val = int(val)
+
+        return val
 
     def read_attr(self, key):
         '''


### PR DESCRIPTION
Working on allowing Terraform resources to more intelligently overlap to provide variables for the same Ansible Inventory host or group.

Without this, if someone defined a resource with the same hostname and variable key, it would be last-in-wins as it processes the state file.

Closes #11 